### PR TITLE
Python 3.9 compatibility

### DIFF
--- a/.github/workflows/verify-plugin-scripts.yml
+++ b/.github/workflows/verify-plugin-scripts.yml
@@ -23,7 +23,7 @@ jobs:
         pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
-        pylint --errors-only $(find . -name "*.py" | xargs)
+        pylint --errors-only $(find src/ -name "*.py" | xargs)
     - name: Running tests
       run: |
         pytest --cov

--- a/.github/workflows/verify-plugin-scripts.yml
+++ b/.github/workflows/verify-plugin-scripts.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11" ]
+        python-version: [ "3.9", "3.10", "3.11" ]
 
     steps:
     - uses: actions/checkout@v4
@@ -23,12 +23,12 @@ jobs:
         pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
-        pylint --fail-under 9 $(find . -name "*.py" | xargs)
+        pylint --errors-only $(find . -name "*.py" | xargs)
     - name: Running tests
       run: |
         pytest --cov
     - name: Archive production artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: munin-plugins
+        name: fritzbox-munin-plugins
         path: src/fritzbox*.py

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ These python scripts are [Munin](http://munin-monitoring.org) plugins for monito
 
 ## Purpose of this Fork
 
-The scripts are build upon the original [fritzbox-munin](https://github.com/Tafkas/fritzbox-munin) with the goal to make use of the modern APIs that FRITZ!OS 7 provides.  
+The scripts are build upon the original [fritzbox-munin](https://github.com/Tafkas/fritzbox-munin) with the goal to make use of the modern APIs that FRITZ!OS 7 provides.
+
 The main differences to the original version are:
 - Compatibility with latest FRITZ!OS version using username/password authentication
-- No HTML Scraping is used
+- No HTML Scraping
 - All data is fetched either through the TR-064 interface or the JSON API
 - Contrary to the original version this fork uses multigraphs: this removes the need to query the same API endpoint multiple times, all multigraph plugins have configuration options to switch individual graphs on and off
 - Support for Smart Home devices, e.g. for measuring temperature
@@ -25,7 +26,7 @@ The main differences to the original version are:
 ## Requirements
 - FRITZ!Box router with FRITZ!OS >= 07.50 (if you are on an older FRITZ!OS version, select an older version of fritzbox-munin-fast by browsing the tags in this repository)
 - Munin 1.4.0 or later is required
-- Python >= 3.10
+- Python >= 3.9
    
 ## Available Plugins
 

--- a/pylintrc
+++ b/pylintrc
@@ -52,7 +52,7 @@ persistent=yes
 
 # Min Python version to use for version dependend checks. Will default to the
 # version used to run pylint.
-py-version=3.10
+py-version=3.9
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
 # user-friendly hints instead of false-positive error messages.

--- a/src/fritzbox_dsl.py
+++ b/src/fritzbox_dsl.py
@@ -25,7 +25,7 @@ from fritzbox_interface import FritzboxInterface
 from fritzbox_munin_plugin_interface import MuninPluginInterface,main_handler
 
 PAGE = 'data.lua'
-PARAMS = {'xhr':1, 'lang':'de', 'page':'dslStat', 'xhrId':'refresh', 'useajax':1, 'no_sidrenew':None}
+PARAMS = {'xhr': 1, 'lang': 'de', 'page': 'dslStat', 'xhrId': 'refresh', 'useajax': 1, 'no_sidrenew': None}
 
 TITLES = {
   'capacity': 'Link Capacity',

--- a/src/fritzbox_file_session.py
+++ b/src/fritzbox_file_session.py
@@ -6,8 +6,6 @@
 import os
 from typing import Optional
 
-NoneOrString = Optional[str]  # for Python 3.9 compatibility, since 3.10 you can type None | str
-
 def get_session_dir() -> str:
   return str(os.getenv('MUNIN_PLUGSTATE')) + '/fritzbox'
 
@@ -40,7 +38,7 @@ class FritzboxFileSession:
     with open(statefilename, 'w', encoding='utf8') as statefile:
       statefile.write(session_id)
 
-  def load(self) -> NoneOrString:
+  def load(self) -> Optional[str]:
     statefilename = get_session_dir() + '/' + self.__get_session_filename()
     if not os.path.exists(statefilename):
       return None

--- a/src/fritzbox_file_session.py
+++ b/src/fritzbox_file_session.py
@@ -4,6 +4,9 @@
 """
 
 import os
+from typing import Optional
+
+NoneOrString = Optional[str]  # for Python 3.9 compatibility, since 3.10 you can type None | str
 
 def get_session_dir() -> str:
   return str(os.getenv('MUNIN_PLUGSTATE')) + '/fritzbox'
@@ -37,7 +40,7 @@ class FritzboxFileSession:
     with open(statefilename, 'w', encoding='utf8') as statefile:
       statefile.write(session_id)
 
-  def load(self) -> None | str:
+  def load(self) -> NoneOrString:
     statefilename = get_session_dir() + '/' + self.__get_session_filename()
     if not os.path.exists(statefilename):
       return None


### PR DESCRIPTION
As Python 3.9 is the default version on Raspberry Pi OS, this PR makes the scripts compatible with this version.
Also it [is supported](https://www.python.org/downloads/) until 2025-10.

Fixes https://github.com/ma4nn/fritzbox-munin-fast/issues/16